### PR TITLE
added Dockerfile to create the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.dockerignore
+.gitignore
+.pre-commit-config.yaml
+Dockerfile
+LICENSE
+README.md
+*/.env
+
+.git/
+.github/
+test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@
 ## Using Alpine version because it's lightweight
 FROM python:3.8-alpine
 WORKDIR /app
-COPY . .
 
 RUN apk update && apk upgrade && \
     pip install pipenv && \
     pipenv install --ignore-pipfile
+
+COPY . .
 
 CMD ["pipenv", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,11 @@
 ## To implement
+## Using Alpine version because it's lightweight
+FROM python:3.8-alpine
+WORKDIR /app
+COPY . .
+
+RUN apk update && apk upgrade && \
+    pip install pipenv && \
+    pipenv install --ignore-pipfile
+
+CMD ["pipenv", "run", "start"]


### PR DESCRIPTION
# Description

This PR adds the Dockerfile so we can use it to create Docker images.

Closes #5 

# How Has This Been Tested?

Tested by doing 
`docker build -t oxygencs-grp1-eq5 .`, 
and
 `docker run --env-file /path/to/oxygencs-grp1-eq5/src/.env oxygencs-grp1-eq5 `.

I was able to connect.