### PR TITLE
Ajout du build&push de l'image docker (une fois merge sur main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,31 @@ jobs:
       - name: Run formatter
         run: |
           python -m black src/ test/
+
+  build_push_image:
+    needs: build
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Check out Repo
+      - name: Login to Docker Hub
+        uses: docker/login-actions@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: 191180611497/oxygencs-grp1-eq5
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: 191180611497/oxygencs-grp1-eq5
+          images: 191180611401/oxygencs-grp1-eq5
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: 191180611401/oxygencs-grp1-eq5
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/oxygencs-grp1-eq5
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
# Description

Fait en sorte qu'une fois les PR merge sur main, l'image Docker est construite et envoyée sur DockerHub.

Closes #14 

