### PR TITLE
Added the Kubernetes secrets for oxygencs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,19 @@ python3 -m pipenv --python /the/python3/binary/location run pre-commit install
 
 On linux, the default python3 path is : `/usr/bin/python3`
 
+> Note: If nothing worked, try to use `venv` to create a virtual environnement, install pipenv with `pip install pipenv`, then run `pipenv install -d`. <br><br>On Visual Studio code, using `Ctrl+shift+p`, you can find the command "Python: Select Interpreter" and create a new virtual environnement using venv or Conda.
+
 ## Setup
 
-You need to setup the following variables inside `/.env` file:
+Create a `.env` file at the root of `oxygencs-grp1-eq5`
 
-- HOST: The host of the sensor hub and HVAC system.
-- TOKEN: The token for authenticating requests.
-- T_MAX: The maximum allowed temperature.
-- T_MIN: The minimum allowed temperature.
-- DATABASE_URL: The database connection URL.
+In this `.env` file, you need to setup the following variables:
+
+- `HOST`: The host of the sensor hub and HVAC system.
+- `TOKEN`: The token for authenticating requests.
+- `T_MAX`:  maximum allowed temperature.
+- `T_MIN`: The minimum allowed temperature.
+- `DATABASE_URL`: The database connection URL.<br>It should be formatted like this: `postgresql://username:password@ip:port/db-name`
 
 ## Running the Program
 

--- a/infra/secrets.yaml
+++ b/infra/secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oxygencs-secrets
+data:
+  token: CHANGE-THIS    # Base64 encoded value of 'GITHUB_TOKEN'
+  database-url: CHANGE-THIS   # Base64 encoded value of 'DATABASE_PASSWORD'


### PR DESCRIPTION
# Description

Creates a Kubernetes resource to configure the secrets of the repository. Obviously, the values are not committed because that would be dumb.

What was added to the cluster:
![image](https://github.com/user-attachments/assets/d52bc751-e2ca-46d0-946a-6ec020c2bcc4)


Fixes #30 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

The secrets have been applied to the Kubernetes cluster on the school server. The values are good.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules