### PR TITLE
Added deployment of oxygencs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,4 +9,6 @@ README.md
 
 .git/
 .github/
+.venv/
+infra/
 test/

--- a/infra/configMap.yaml
+++ b/infra/configMap.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: oxygencs-config-map
 data:
-  host: "http://159.203.50.162/"
-  t_min: "20"
+  host: "http://159.203.50.162"
+  t_min: "10"
   t_max: "30"

--- a/infra/deployment.yaml
+++ b/infra/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oxygencs-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: oxygencs
+  template:
+    metadata:
+      labels:
+        app: oxygencs
+    spec:
+      containers:
+        - name: oxygencs-container
+          image: 191180611401/oxygencs-grp1-eq5:latest
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "300Mi"
+              cpu: "300m"
+          env:
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: oxygencs-secrets
+                  key: token
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: oxygencs-secrets
+                  key: database-url
+            - name: HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: oxygencs-config-map
+                  key: host
+            - name: T_MIN
+              valueFrom:
+                configMapKeyRef:
+                  name: oxygencs-config-map
+                  key: t_min
+            - name: T_MAX
+              valueFrom:
+                configMapKeyRef:
+                  name: oxygencs-config-map
+                  key: t_max


### PR DESCRIPTION
# Description

A deployment for the oxygencs application has been created. It has a single replica that has one pod that runs the oxygencs app connected with the database and using the secrets and config map.
- The deployment
![image](https://github.com/user-attachments/assets/8b81a6fe-75b3-4c8f-9184-431b83d9f5e0)

- The pod
![image](https://github.com/user-attachments/assets/4e209269-cec9-447a-b504-ed3d9c4609a9)

- The container
![image](https://github.com/user-attachments/assets/eb37fd16-4c55-4397-b2cd-653eba1a035a)

- The logs
![image](https://github.com/user-attachments/assets/cc8dbabe-8c4f-439a-a6e5-3da48985d1e6)

- The Grafana dashboard being updated
![image](https://github.com/user-attachments/assets/57649b55-0f48-4146-a0d0-4d4510cc6493)

Fixes #32 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] The documentation is done?

# How Has This Been Tested?

I've played with it and applied it to the cluster successfully