### PR TITLE
fixed typo in kubectl command workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,6 @@ jobs:
           echo "${{ secrets.KUBECONF }}" | base64 --decode > $HOME/.kube/config
       - name: Deploy to Kubernetes
         run: |
-          kubectl apply -f infra/
+          kubectl apply -k infra/
       - name: Restart Kubernetes to get new image
         run: kubectl rollout restart deployment oxygencs-deployment


### PR DESCRIPTION
# Description

Fixed a typo in `kubectl apply` command. Changed flag from -f to -k since the apply is made on a directory


- [ ] Bug fix (non-breaking change which fixes an issue)

